### PR TITLE
Make a link between events and todoist projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ TODOIST_TOKEN="Todoist Token"
 # PostgreSQL database URL:
 POSTGRES_URL="Postgres URL"
 
+# How many days you want to fecth on Todoist (default: 7):
+DAYSTOFECTH="7"
+
 # Ignored events (comma-separated list of event names):
 IGNORE_EVENTS="Absent au bureau,Running"
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ DAYSTOFECTH="7"
 IGNORE_EVENTS="Absent au bureau,Running"
 ```
 
+You can also sync events from your Google Calendar with Todoist projects, for that you'll need to acces to the database and then go to the table `EventsSyncProjects`.
+
+Create a new row in the table with the properties :
+- `projectID`: The ID of the Todoist project (you can find it at the end of the url e.g: https://app.todoist.com/app/project/name-123456789)
+- `email` (optional): The email associated with a Google Calendar (all events from this calendar will go into the project)
+- `eventTitles` (optional): A list of event titles from your Google Calendar (all events that start with these titles will go into the project e.g: Lunch time, Focus time...)
+- `priority`: Defines the order of priority for applying different filter rules
+
+You must use at least either `email` or `eventTitles` to filter events into a Todoist project.
+
 ## Contributing
 Contributions are welcome! Feel free to submit issues or pull requests.
 

--- a/prisma/migrations/20240924171232_add_link_between_events_and_todoist_projects/migration.sql
+++ b/prisma/migrations/20240924171232_add_link_between_events_and_todoist_projects/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "EventsSyncProjects" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "projectID" TEXT NOT NULL,
+
+    CONSTRAINT "EventsSyncProjects_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20240924214448_update_events_sync_projects/migration.sql
+++ b/prisma/migrations/20240924214448_update_events_sync_projects/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[priority]` on the table `EventsSyncProjects` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `priority` to the `EventsSyncProjects` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "EventsSyncProjects" ADD COLUMN     "calendarName" TEXT,
+ADD COLUMN     "eventTitles" TEXT[],
+ADD COLUMN     "priority" INTEGER NOT NULL,
+ALTER COLUMN "email" DROP NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EventsSyncProjects_priority_key" ON "EventsSyncProjects"("priority");

--- a/prisma/migrations/20240925083200_remove_calendar_name/migration.sql
+++ b/prisma/migrations/20240925083200_remove_calendar_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `calendarName` on the `EventsSyncProjects` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "EventsSyncProjects" DROP COLUMN "calendarName";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,3 +26,10 @@ model EventSync {
   googleEventID    String
   googleLastUpdate DateTime
 }
+
+model EventsSyncProjects {
+  id String @id @default(uuid())
+
+  email     String
+  projectID String
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,8 @@ model EventSync {
 model EventsSyncProjects {
   id String @id @default(uuid())
 
-  email     String
-  projectID String
+  projectID   String
+  email       String?
+  eventTitles String[]
+  priority    Int      @unique
 }

--- a/src/features/sync.ts
+++ b/src/features/sync.ts
@@ -20,7 +20,7 @@ const logUpdate = (action: "created" | "updated" | "deleted", event: CalendarEve
 };
 
 const createNextEvents = async(email: string): Promise<void> => {
-  const events = await google.getEvents(email, day(), day().add(env.DAYSTOFECTH, "day"));
+  const events = await google.getEvents(email, day(), day().add(Number(env.DAYSTOFECTH), "day"));
   const syncWithProjects = await db.eventsSyncProjects.findMany({
     orderBy: { priority: "asc" }
   });
@@ -57,7 +57,7 @@ const createNextEvents = async(email: string): Promise<void> => {
             event.description || ""
           ].join("\n\n"),
           dueDatetime: dueDateTime,
-          projectID: project.projectID,
+          projectId: project.projectID,
           ...duration
         });
 
@@ -80,7 +80,7 @@ const createNextEvents = async(email: string): Promise<void> => {
 };
 
 const updateEvents = async(email: string): Promise<void> => {
-  const eventsGoogle = await google.getEvents(email, day(), day().add(env.DAYSTOFECTH, "day"));
+  const eventsGoogle = await google.getEvents(email, day(), day().add(Number(env.DAYSTOFECTH), "day"));
   const eventsSync = await db.eventSync.findMany({ where: { googleEventID: { in: eventsGoogle.map(event => event.id!) } } });
 
   for (const eventSync of eventsSync) {

--- a/src/features/sync.ts
+++ b/src/features/sync.ts
@@ -32,7 +32,7 @@ const createNextEvents = async(email: string): Promise<void> => {
     const eventSync = await db.eventSync.findFirst({ where: { googleEventID: event.id! } });
     if (eventSync) continue;
 
-    let duration: { duration?: Duration["amount"]; durationUnit?: Duration["unit"] } | null
+    let duration: { duration: Duration["amount"]; durationUnit: Duration["unit"] } | null
       = (event.end && event.start ? {
         duration: day(event.end.dateTime).diff(event.start.dateTime, "minute"),
         durationUnit: "minute"
@@ -92,7 +92,7 @@ const updateEvents = async(email: string): Promise<void> => {
 
         logUpdate("deleted", eventGoogle);
       } else {
-        let duration: { duration?: Duration["amount"]; durationUnit?: Duration["unit"] } | null
+        let duration: { duration: Duration["amount"]; durationUnit: Duration["unit"] } | null
         = (eventGoogle.end && eventGoogle.start ? {
           duration: day(eventGoogle.end.dateTime).diff(eventGoogle.start.dateTime, "minute"),
           durationUnit: "minute"

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -14,6 +14,8 @@ const schema = z.object({
 
   POSTGRES_URL: z.string().url(),
 
+  DAYSTOFECTH: z.coerce.number().default(3),
+
   IGNORE_EVENTS: z.string().transform(value => value.split(",")).optional()
 });
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -14,7 +14,7 @@ const schema = z.object({
 
   POSTGRES_URL: z.string().url(),
 
-  DAYSTOFECTH: z.coerce.number().default(3),
+  DAYSTOFECTH: z.coerce.number().default(7),
 
   IGNORE_EVENTS: z.string().transform(value => value.split(",")).optional()
 });


### PR DESCRIPTION
The objectives of this pull request is to make a link between an events from your Google Agenda and a project from Todoist.

Actually when the system pull all the events from your calendar, he had it automatically on your todoist, but if you want to manage all of the events with your Todoist projects, you have to add manualy every events to a project.

This pull request to make this automatic.